### PR TITLE
Fix percentile names bug, and make percentiles a constructor arg

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -13,6 +13,7 @@ func main() {
 		nil,              // Metrics registry, or nil for default
 		"127.0.0.1:8125", // DogStatsD UDP address
 		time.Second*10,   // Update interval
+		datadog.UsePercentiles([]float64{0.25, 0.99}),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -1,0 +1,38 @@
+package datadog
+
+import "testing"
+
+func TestGetPercentileNamesOutOfRange(t *testing.T) {
+	_, err := getPercentileNames([]float64{0.23, 0})
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+	_, err = getPercentileNames([]float64{0.23, 1})
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+	_, err = getPercentileNames([]float64{0.23, -0.1})
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+	_, err = getPercentileNames([]float64{0.23, 2})
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}
+func TestGetPercentileNames(t *testing.T) {
+	percentiles := []float64{0.23, 0.4, 0.99999, 0.45346356}
+	names, err := getPercentileNames(percentiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedNames := []string{".p23", ".p4", ".p99999", ".p45346356"}
+	if len(expectedNames) != len(names) {
+		t.Fatalf("Expected names: %v, got: %v", expectedNames, names)
+	}
+	for i, expectedName := range expectedNames {
+		if names[i] != expectedName {
+			t.Fatalf("Expected names: %v, got: %v", expectedNames, names)
+		}
+	}
+}

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -3,36 +3,34 @@ package datadog
 import "testing"
 
 func TestGetPercentileNamesOutOfRange(t *testing.T) {
-	_, err := getPercentileNames([]float64{0.23, 0})
-	if err == nil {
+	reporter := &Reporter{}
+	if UsePercentiles([]float64{0.23, 0})(reporter) == nil {
 		t.Fatal("Expected error")
 	}
-	_, err = getPercentileNames([]float64{0.23, 1})
-	if err == nil {
+	if UsePercentiles([]float64{0.23, 1})(reporter) == nil {
 		t.Fatal("Expected error")
 	}
-	_, err = getPercentileNames([]float64{0.23, -0.1})
-	if err == nil {
+	if UsePercentiles([]float64{0.23, -0.1})(reporter) == nil {
 		t.Fatal("Expected error")
 	}
-	_, err = getPercentileNames([]float64{0.23, 2})
-	if err == nil {
+	if UsePercentiles([]float64{0.23, 2})(reporter) == nil {
 		t.Fatal("Expected error")
 	}
 }
 func TestGetPercentileNames(t *testing.T) {
+	reporter := &Reporter{}
 	percentiles := []float64{0.23, 0.4, 0.99999, 0.45346356}
-	names, err := getPercentileNames(percentiles)
+	err := UsePercentiles(percentiles)(reporter)
 	if err != nil {
 		t.Fatal(err)
 	}
 	expectedNames := []string{".p23", ".p4", ".p99999", ".p45346356"}
-	if len(expectedNames) != len(names) {
-		t.Fatalf("Expected names: %v, got: %v", expectedNames, names)
+	if len(expectedNames) != len(reporter.p) {
+		t.Fatalf("Expected names: %v, got: %v", expectedNames, reporter.p)
 	}
 	for i, expectedName := range expectedNames {
-		if names[i] != expectedName {
-			t.Fatalf("Expected names: %v, got: %v", expectedNames, names)
+		if reporter.p[i] != expectedName {
+			t.Fatalf("Expected names: %v, got: %v", expectedNames, reporter.p)
 		}
 	}
 }


### PR DESCRIPTION
Currently the percentiles for timed metrics don't populate in datadog since the variable `p` is never initialized when constructing the Reporter. This PR fixes that, and also allows for generalized percentiles via a ctor argument.